### PR TITLE
Parital swagger API documentation

### DIFF
--- a/__test__/mapstats.test.js
+++ b/__test__/mapstats.test.js
@@ -82,14 +82,14 @@ describe('Delete Mapstats', () => {
             map_stats_id: 1,
         }];
         request
-            .delete('/mapstats/delete')
+            .delete('/mapstats')
             .set("Content-Type", "application/json")
             .set("Accept", "application/json")
             .send(teamData)
+            .expect(200)
             .expect((result) => {
                 expect(result.body.message).toMatch(/successfully/);
             })
-            .expect(200)
             .end(done);
     });
 });

--- a/__test__/users.test.js
+++ b/__test__/users.test.js
@@ -43,13 +43,13 @@ describe('Get Steam URL', () => {
 describe('Setup New User', () => {
   it('Should setup a new user only if we are an admin or super_admin.', async done => {
     let newUserData = [{
-      id: 1, 
-      steam_id: 1234, 
-      name: "Test User", 
+      id: 1,
+      steam_id: 1234,
+      name: "Test User",
       admin: 0,
       super_admin: 0
     }];
-    request.post('/users/create').
+    request.post('/users').
     set('Content-Type', 'application/json').
     set('Accept', 'application/json').
     send(newUserData).
@@ -66,7 +66,7 @@ describe('Update User', () => {
       admin: 0,
       super_admin: 0
     }];
-    request.put('/users/update').
+    request.put('/users').
     set('Content-Type', 'application/json').
     set('Accept', 'application/json').
     send(updatedUserData).
@@ -83,11 +83,11 @@ describe('Attempt New User', () => {
       admin: 1,
       super_admin: 1
     }];
-    request.post('/users/create').
+    request.post('/users').
     set('Content-Type', 'application/json').
     set('Accept', 'application/json').
     send(newUserData).
-    expect(401, done);
+    expect(403, done);
   });
 });
 

--- a/app.js
+++ b/app.js
@@ -21,12 +21,16 @@ const usersRouter = require("./routes/users");
 const vetoesRouter = require("./routes/vetoes");
 //End Route Files
 
+const swaggerUi = require('swagger-ui-express');
+const swaggerJSDoc = require('swagger-jsdoc');
+
 const passport = require("./utility/auth");
 const jwt = require("jsonwebtoken");
 const bearerToken = require("express-bearer-token");
 const config = require("config");
 const session = require("express-session");
 const redis = require("redis");
+
 // Messy but avoids any open file handles.
 const redisClient =
   process.env.NODE_ENV !== "test"
@@ -35,6 +39,7 @@ const redisClient =
       })
     : require("redis-mock").createClient();
 const redisStore = require("connect-redis")(session);
+
 const app = express();
 
 app.use(logger("dev"));
@@ -52,6 +57,7 @@ const redisCfg = {
   ttl: config.get(process.env.NODE_ENV + ".redisTTL"),
 };
 
+// Security defaults with helmet
 app.use(helmet());
 app.use(
   session({
@@ -73,6 +79,23 @@ app.use(cors());
 
 // adding morgan to log HTTP requests
 app.use(morgan("combined"));
+
+// swagger UI
+
+const options = {
+  definition: {
+    openapi: '3.0.0', // Specification (optional, defaults to swagger: '2.0')
+    info: {
+      title: 'G5API', // Title (required)
+      version: '0.1.0', // Version (required)
+    },
+  },
+  // Path to the API docs
+  apis: ['./routes/leaderboard.js','./routes/mapstats.js','./routes/users.js'],
+};
+const swaggerSpec = swaggerJSDoc(options);
+
+app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 
 // END API SETUP
 

--- a/package.json
+++ b/package.json
@@ -83,7 +83,9 @@
     "rcon-srcds": "^1.2.0",
     "redis": "^3.0.2",
     "redis-mock": "^0.49.0",
-    "steamapi": "^2.0.7"
+    "steamapi": "^2.0.7",
+    "swagger-jsdoc": "^4.0.0",
+    "swagger-ui-express": "^4.1.4"
   },
   "devDependencies": {
     "jest": "^25.1.0",

--- a/routes/leaderboard.js
+++ b/routes/leaderboard.js
@@ -21,12 +21,56 @@ const db = require("../db");
  */
 const Utils = require("../utility/utils");
 
-/** GET - Route serving to get lifetime leaderboard of teams.
- * @name router.get('/')
- * @function
- * @memberof module:routes/leaderboard
- * @param {string} path - Express path
- * @param {callback} middleware - Express middleware.
+
+/**
+ * @swagger
+ *
+ * components:
+ *   schemas:
+ *     SimpleResponse:
+ *       type: object
+ *       properties:
+ *         message:
+ *           type: string
+ *   responses:
+ *     BadRequest:
+ *       description: Match ID not provided
+ *     NotFound:
+ *       description: The specified resource was not founds
+ *     Unauthorized:
+ *       description: Unauthorized
+ *     MatchAlreadyFinished:
+ *       description: Match already finisheds
+ *     MatchNotFound:
+ *       description: Match not founds
+ *     Error:
+ *       description: Error
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/SimpleResponse'
+ */
+
+
+/**
+ * @swagger
+ *
+ * /leaderboard/:
+ *   get:
+ *     description: Get lifetime leaderboard of teams
+ *     produces:
+ *       - application/json
+ *     tags:
+ *       - leaderboard
+ *     responses:
+ *       200:
+ *         description: Leaderboard
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/SimpleResponse'
+ *       500:
+ *         $ref: '#/components/responses/Error'
  */
 router.get("/", async (req, res) => {
   try {
@@ -37,12 +81,26 @@ router.get("/", async (req, res) => {
   }
 });
 
-/** GET - Route serving to get a lifetime leaderboard for players.
- * @name router.get('/players')
- * @function
- * @memberof module:routes/leaderboard
- * @param {string} path - Express path
- * @param {callback} middleware - Express middleware.
+
+/**
+ * @swagger
+ *
+ * /leaderboard/players:
+ *   get:
+ *     description: Get lifetime leaderboard for players
+ *     produces:
+ *       - application/json
+ *     tags:
+ *       - leaderboard
+ *     responses:
+ *       200:
+ *         description: Leaderboard
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/SimpleResponse'
+ *       500:
+ *         $ref: '#/components/responses/Error'
  */
 router.get("/players", async (req, res) => {
   try {
@@ -54,13 +112,29 @@ router.get("/players", async (req, res) => {
   }
 });
 
-/** GET - Route serving to get a seasonal leaderboard for players.
- * @name router.get('/players/:season_id')
- * @function
- * @memberof module:routes/leaderboard
- * @param {string} path - Express path
- * @param {callback} middleware - Express middleware.
- * @param {integer} season_id - Season ID to examine.
+/**
+ * @swagger
+ *
+ * /leaderboard/players/:season_id:
+ *   get:
+ *     description: Seasonal leaderboard for players
+ *     produces:
+ *       - application/json
+ *     parameters:
+ *       - name: season_id
+ *         required: true
+ *         type: string
+ *     tags:
+ *       - leaderboard
+ *     responses:
+ *       200:
+ *         description: Leaderboard
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/SimpleResponse'
+ *       500:
+ *         $ref: '#/components/responses/Error'
  */
 router.get("/players/:season_id", async (req, res) => {
   try {
@@ -73,13 +147,29 @@ router.get("/players/:season_id", async (req, res) => {
   }
 });
 
-/** GET - Route serving to get a season leaderboard of teams.
- * @name router.get('/:season_id')
- * @function
- * @memberof module:routes/leaderboard
- * @param {string} path - Express path
- * @param {integer} season_id - The season ID to query over for matches.
- * @param {callback} middleware - Express middleware.
+/**
+ * @swagger
+ *
+ * /leaderboard/:
+ *   get:
+ *     description: Seasonal leaderboard for teams
+ *     produces:
+ *       - application/json
+ *     tags:
+ *       - leaderboard
+ *     parameters:
+ *       - name: season_id
+ *         required: true
+ *         type: string
+ *     responses:
+ *       200:
+ *         description: Leaderboard
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/SimpleResponse'
+ *       500:
+ *         $ref: '#/components/responses/Error'
  */
 router.get("/:season_id", async (req, res) => {
   try {
@@ -191,31 +281,31 @@ const getPlayerLeaderboard = async (seasonId = null) => {
    * 2. Grab raw values, and calculate things like HSP and KDR for each user. Get names and cache 'em even.
    * 3. Insert into list of objects for each user.
    */
-  let playerStatSql = `SELECT  steam_id, name, sum(kills) as kills, 
+  let playerStatSql = `SELECT  steam_id, name, sum(kills) as kills,
     sum(deaths) as deaths, sum(assists) as assists, sum(k1) as k1,
-    sum(k2) as k2, sum(k3) as k3, 
-    sum(k4) as k4, sum(k5) as k5, sum(v1) as v1, 
-    sum(v2) as v2, sum(v3) as v3, sum(v4) as v4, 
-    sum(v5) as v5, sum(roundsplayed) as trp, sum(flashbang_assists) as fba, 
-    sum(damage) as dmg, sum(headshot_kills) as hsk
-    FROM    player_stats 
-    WHERE   match_id IN (
-        SELECT  id 
-        FROM    \`match\` 
-        WHERE   cancelled=0
-    )
-    GROUP BY steam_id, name`;
-  let playerStatSqlSeasons = `SELECT  steam_id, name, sum(kills) as kills, 
-    sum(deaths) as deaths, sum(assists) as assists, sum(k1) as k1,
-    sum(k2) as k2, sum(k3) as k3, 
-    sum(k4) as k4, sum(k5) as k5, sum(v1) as v1, 
-    sum(v2) as v2, sum(v3) as v3, sum(v4) as v4, 
-    sum(v5) as v5, sum(roundsplayed) as trp, sum(flashbang_assists) as fba, 
+    sum(k2) as k2, sum(k3) as k3,
+    sum(k4) as k4, sum(k5) as k5, sum(v1) as v1,
+    sum(v2) as v2, sum(v3) as v3, sum(v4) as v4,
+    sum(v5) as v5, sum(roundsplayed) as trp, sum(flashbang_assists) as fba,
     sum(damage) as dmg, sum(headshot_kills) as hsk
     FROM    player_stats
     WHERE   match_id IN (
-        SELECT  id 
-        FROM    \`match\` 
+        SELECT  id
+        FROM    \`match\`
+        WHERE   cancelled=0
+    )
+    GROUP BY steam_id, name`;
+  let playerStatSqlSeasons = `SELECT  steam_id, name, sum(kills) as kills,
+    sum(deaths) as deaths, sum(assists) as assists, sum(k1) as k1,
+    sum(k2) as k2, sum(k3) as k3,
+    sum(k4) as k4, sum(k5) as k5, sum(v1) as v1,
+    sum(v2) as v2, sum(v3) as v3, sum(v4) as v4,
+    sum(v5) as v5, sum(roundsplayed) as trp, sum(flashbang_assists) as fba,
+    sum(damage) as dmg, sum(headshot_kills) as hsk
+    FROM    player_stats
+    WHERE   match_id IN (
+        SELECT  id
+        FROM    \`match\`
         WHERE   cancelled=0
         AND season_id = ?
     )

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,38 @@
 # yarn lockfile v1
 
 
+"@apidevtools/json-schema-ref-parser@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-8.0.0.tgz#9eb749499b3f8d919e90bb141e4b6f67aee4692d"
+  integrity sha512-n4YBtwQhdpLto1BaUCyAeflizmIbaloGShsPyRtFf5qdFJxfssj+GgLavczgKJFa3Bq+3St2CKcpRJdjtB4EBw==
+  dependencies:
+    "@jsdevtools/ono" "^7.1.0"
+    call-me-maybe "^1.0.1"
+    js-yaml "^3.13.1"
+
+"@apidevtools/openapi-schemas@^2.0.2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@apidevtools/openapi-schemas/-/openapi-schemas-2.0.3.tgz#c21f198b445bc8b8a90cd4f97534b96deefdfcb4"
+  integrity sha512-QoPaxGXfgqgGpK1p21FJ400z56hV681a8DOcZt3J5z0WIHgFeaIZ4+6bX5ATqmOoCpRCsH4ITEwKaOyFMz7wOA==
+
+"@apidevtools/swagger-methods@^3.0.0":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@apidevtools/swagger-methods/-/swagger-methods-3.0.1.tgz#cf3b1c6b92f811d3f14d51645d277fb54ddd5211"
+  integrity sha512-1Vlm18XYW6Yg7uHunroXeunWz5FShPFAdxBbPy8H6niB2Elz9QQsCoYHMbcc11EL1pTxaIr9HXz2An/mHXlX1Q==
+
+"@apidevtools/swagger-parser@9.0.1":
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/@apidevtools/swagger-parser/-/swagger-parser-9.0.1.tgz#592e39dc412452ac4b34507a765e4d74ff6eda14"
+  integrity sha512-Irqybg4dQrcHhZcxJc/UM4vO7Ksoj1Id5e+K94XUOzllqX1n47HEA50EKiXTCQbykxuJ4cYGIivjx/MRSTC5OA==
+  dependencies:
+    "@apidevtools/json-schema-ref-parser" "^8.0.0"
+    "@apidevtools/openapi-schemas" "^2.0.2"
+    "@apidevtools/swagger-methods" "^3.0.0"
+    "@jsdevtools/ono" "^7.1.0"
+    call-me-maybe "^1.0.1"
+    openapi-types "^1.3.5"
+    z-schema "^4.2.2"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.8.3.tgz#33e25903d7481181534e12ec0a25f16b6fcf419e"
@@ -436,6 +468,11 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
+
+"@jsdevtools/ono@^7.1.0":
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/@jsdevtools/ono/-/ono-7.1.2.tgz#373995bb40a6686589a7fcfec06b0e6e304ef6c6"
+  integrity sha512-qS/a24RA5FEoiJS9wiv6Pwg2c/kiUo3IVUQcfeM9JvsR6pM8Yx+yl/6xWYLckZCT5jpLNhslgjiA8p/XcGyMRQ==
 
 "@node-steam/id@^1.1.0":
   version "1.1.0"
@@ -998,6 +1035,11 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
+call-me-maybe@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/call-me-maybe/-/call-me-maybe-1.0.1.tgz#26d208ea89e37b5cbde60250a15f031c16a4d66b"
+  integrity sha1-JtII6onje1y95gJQoV8DHBak1ms=
+
 callsites@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
@@ -1178,6 +1220,16 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
+
+commander@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-5.0.0.tgz#dbf1909b49e5044f8fdaf0adc809f0c0722bdfd0"
+  integrity sha512-JrDGPAKjMGSP1G0DUoaceEJ3DZgAfr/q6X7FVk4+U5KxUSKviYGM2k6zWkfyyBHy5rAtzgYJFa1ro2O9PtoxwQ==
+
+commander@^2.7.1:
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
 component-emitter@^1.2.0, component-emitter@^1.2.1:
   version "1.3.0"
@@ -1527,6 +1579,13 @@ dns-prefetch-control@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/dns-prefetch-control/-/dns-prefetch-control-0.2.0.tgz#73988161841f3dcc81f47686d539a2c702c88624"
   integrity sha512-hvSnros73+qyZXhHFjx2CMLwoj3Fe7eR9EJsFsqmcI1bB2OBWL/+0YzaEaKssCHnj/6crawNnUyw74Gm2EKe+Q==
+
+doctrine@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
+  integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
+  dependencies:
+    esutils "^2.0.2"
 
 domexception@^1.0.1:
   version "1.0.1"
@@ -2054,7 +2113,7 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
-glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
+glob@7.1.6, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -2987,7 +3046,7 @@ js-tokens@^4.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.13.1:
+js-yaml@3.13.1, js-yaml@^3.13.1:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
@@ -3214,6 +3273,11 @@ lodash.defaults@^4.1.0:
   resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
   integrity sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=
 
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
+
 lodash.includes@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
@@ -3223,6 +3287,11 @@ lodash.isboolean@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
   integrity sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=
+
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+  integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
 
 lodash.isinteger@^4.0.4:
   version "4.0.4"
@@ -3719,6 +3788,11 @@ onetime@^5.1.0:
   integrity sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==
   dependencies:
     mimic-fn "^2.1.0"
+
+openapi-types@^1.3.5:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/openapi-types/-/openapi-types-1.3.5.tgz#6718cfbc857fe6c6f1471f65b32bdebb9c10ce40"
+  integrity sha512-11oi4zYorsgvg5yBarZplAqbpev5HkuVNPlZaPTknPDzAynq+lnJdXAmruGWP0s+dNYZS7bjM+xrTpJw7184Fg==
 
 openid@2.x.x:
   version "2.0.6"
@@ -4810,6 +4884,36 @@ supports-hyperlinks@^2.0.0:
     has-flag "^4.0.0"
     supports-color "^7.0.0"
 
+swagger-jsdoc@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/swagger-jsdoc/-/swagger-jsdoc-4.0.0.tgz#e39f126e60a957f6bb438d26230a368152f5bbeb"
+  integrity sha512-wHrmRvE/OQa3d387YIrRNPvsPwxkJc0tAYeCVa359gUIKPjC4ReduFhqq/+4erLUS79kY1T5Fv0hE0SV/PgBig==
+  dependencies:
+    commander "5.0.0"
+    doctrine "3.0.0"
+    glob "7.1.6"
+    js-yaml "3.13.1"
+    swagger-parser "9.0.1"
+
+swagger-parser@9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/swagger-parser/-/swagger-parser-9.0.1.tgz#338e7e1ec10699069741535a7ef227a6efccbcd4"
+  integrity sha512-oxOHUaeNetO9ChhTJm2fD+48DbGbLD09ZEOwPOWEqcW8J6zmjWxutXtSuOiXsoRgDWvORYlImbwM21Pn+EiuvQ==
+  dependencies:
+    "@apidevtools/swagger-parser" "9.0.1"
+
+swagger-ui-dist@^3.18.1:
+  version "3.26.2"
+  resolved "https://registry.yarnpkg.com/swagger-ui-dist/-/swagger-ui-dist-3.26.2.tgz#22c700906c8911b1c9956da6c3fca371dba6219f"
+  integrity sha512-cpR3A9uEs95gGQSaIXgiTpnetIifTF1u2a0fWrnVl+HyLpCdHVgOy7FGlVD1iVkts7AE5GOiGjA7VyDNiRaNgw==
+
+swagger-ui-express@^4.1.4:
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/swagger-ui-express/-/swagger-ui-express-4.1.4.tgz#8b814ad998b850a1cf90e71808d6d0a8a8daf742"
+  integrity sha512-Ea96ecpC+Iq9GUqkeD/LFR32xSs8gYqmTW1gXCuKg81c26WV6ZC2FsBSPVExQP6WkyUuz5HEiR0sEv/HCC343g==
+  dependencies:
+    swagger-ui-dist "^3.18.1"
+
 symbol-tree@^3.2.2:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
@@ -5143,6 +5247,11 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
+validator@^12.0.0:
+  version "12.2.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-12.2.0.tgz#660d47e96267033fd070096c3b1a6f2db4380a0a"
+  integrity sha512-jJfE/DW6tIK1Ek8nCfNFqt8Wb3nzMoAbocBF6/Icgg1ZFSBpObdnwVY2jQj6qUqzhx5jc71fpvBWyLGO7Xl+nQ==
+
 vary@^1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
@@ -5357,3 +5466,14 @@ yargs@^15.3.1:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.1"
+
+z-schema@^4.2.2:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/z-schema/-/z-schema-4.2.3.tgz#85f7eea7e6d4fe59a483462a98f511bd78fe9882"
+  integrity sha512-zkvK/9TC6p38IwcrbnT3ul9in1UX4cm1y/VZSs4GHKIiDCrlafc+YQBgQBUdDXLAoZHf2qvQ7gJJOo6yT1LH6A==
+  dependencies:
+    lodash.get "^4.4.2"
+    lodash.isequal "^4.5.0"
+    validator "^12.0.0"
+  optionalDependencies:
+    commander "^2.7.1"


### PR DESCRIPTION
Swagger implemented for users, leaderboard and mapstats endpoints.
Documentation available on path `/api-docs`.

I planned to keep the original jsdoc comments but swagger did not 
work without it so they had to go. But does it not look like the jsdocs 
on the express routes was picked up by jsdocs anyways.

Changed some routes/paths to be more "RESTy". Create, update and
delete routes could go straight on root path for the resources.
Ex: `POST /users` instead of `POST /users/create`.
I can undo the route/path changes if you don't approve of it. :)

Resolves #35.