### PR TITLE
Possible fix for #60

### DIFF
--- a/routes/matches/matchserver.js
+++ b/routes/matches/matchserver.js
@@ -202,6 +202,21 @@ router.get(
       res.status(401).json({ message: "Match is already finished." });
       return;
     } else {
+      let getServerSQL =
+        "SELECT ip_string, port, rcon_password FROM game_server WHERE id=?";
+      if (matchRow[0].server_id != null) {
+        const serverRow = await db.query(getServerSQL, [matchRow[0].server_id]);
+        let serverUpdate = new GameServer(
+          serverRow[0].ip_string,
+          serverRow[0].port,
+          serverRow[0].rcon_password
+        );
+        if (!serverUpdate.endGet5Match()) {
+          console.log(
+            "Error attempting to stop match on game server side. Will continue."
+          );
+        }
+      }
       let mapStatSql =
         "SELECT * FROM map_stats WHERE match_id=? AND map_number=0";
       const mapStat = await db.query(mapStatSql, [req.params.match_id]);
@@ -247,21 +262,7 @@ router.get(
           ]);
         }
       });
-      let getServerSQL =
-        "SELECT ip_string, port, rcon_password FROM game_server WHERE id=?";
-      if (matchRow[0].server_id != null) {
-        const serverRow = await db.query(getServerSQL, [matchRow[0].server_id]);
-        let serverUpdate = new GameServer(
-          serverRow[0].ip_string,
-          serverRow[0].port,
-          serverRow[0].rcon_password
-        );
-        if (!serverUpdate.endGet5Match()) {
-          console.log(
-            "Error attempting to stop match on game server side. Will continue."
-          );
-        }
-      }
+      
       res.json({ message: "Match has been cancelled successfully." });
       return;
     }


### PR DESCRIPTION
Move the `Get5EndMatch` call above the database calls, so that we can avoid an error 500 on the game server side once an admin cancels the match.