### PR TITLE
Add Dockerfile and related supporting config files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
 RUN curl https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 
-# install npm
+# install nvm and node 13.8.0
 SHELL ["/bin/bash", "--login", "-c"]
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash
 RUN nvm install 13.8.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+FROM redis:latest
+USER root 
+
+# api port
+EXPOSE 3301
+
+# update and install initial packages
+RUN apt-get update && apt-get upgrade -y && apt-get install -y \
+	curl \
+	apt-transport-https \
+	lsb-release \
+	gnupg
+
+# add yarn repo
+RUN curl https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+
+# install npm
+SHELL ["/bin/bash", "--login", "-c"]
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash
+RUN nvm install 13.8.0
+
+# install yarn
+RUN apt-get update && apt-get install --no-install-recommends -y \
+  yarn
+  
+# copy git files and customized config files to folder Get5API
+RUN mkdir /Get5API && mkdir /RedisFiles
+COPY ./ /Get5API/
+COPY ./config/redis.conf /etc/redis/redis.conf
+COPY ./config/production.json /Get5API/config/production.json
+
+# move into Get5API folder
+WORKDIR /Get5API
+
+# build application
+RUN yarn install --production
+RUN yarn migrate-create-prod && yarn migrate-prod-upgrade && yarn
+
+# run application
+CMD redis-server /etc/redis/redis.conf --daemonize yes --appendonly yes && NODE_ENV=production yarn start

--- a/README.md
+++ b/README.md
@@ -51,11 +51,17 @@ Spins up a development server (by default, please use the `NODE_ENV` variable to
 
 ### Docker Build Instructions:
 This guide assumes you have a MariaDB or MySQL compatible server running. You can deploy one in docker following the [MariaDB guide](https://hub.docker.com/_/mariadb/).
+
 First, you will need to set a password in ```config\redis.conf```.
+
 Next, rename ```config\production.json.template to config\production.json```.
-Fill this file out according to the [configuration](https://github.com/PhlexPlexico/G5API/wiki/Configuration) page. For redisHost, set ```"localhost"```, redisPort ```6379```, redisTTL ```86400```, and redisPass to the password set in ```config\redis.config```.
+
+Fill this file out according to the [configuration](https://github.com/PhlexPlexico/G5API/wiki/Configuration) page. 
+For redisHost, set ```"localhost"```, redisPort ```6379```, redisTTL ```86400```, and redisPass to the password set in ```config\redis.config```.
+
 Now, you can build your docker image.
-Run the command ```docker build -t yourname\g5api:latest .``` Once this has finished, you can run the container using ```docker container run --name g5api -p 3301:3301 -v redisVol:/RedisFiles yourname\g5api:latest```
+Run the command ```docker build -t yourname\g5api:latest .``` 
+Once this has finished, you can run the container using ```docker container run --name g5api -p 3301:3301 -v redisVol:/RedisFiles yourname\g5api:latest```
 
 ### Docs: 
 ```yarn doc```

--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ This will attempt to update a production database by creating any tables that do
 
 Spins up a development server (by default, please use the `NODE_ENV` variable to change this) where you can make all your calls. Since steam authentication is enabled, you will need to auth with steam first before making any calls that would modify any data.
 
+### Docker Build Instructions:
+This guide assumes you have a MariaDB or MySQL compatible server running. You can deploy one in docker following the [MariaDB guide](https://hub.docker.com/_/mariadb/).
+First, you will need to set a password in ```config\redis.conf```.
+Next, rename ```config\production.json.template to config\production.json```.
+Fill this file out according to the [configuration](https://github.com/PhlexPlexico/G5API/wiki/Configuration) page. For redisHost, set ```"localhost"```, redisPort ```6379```, redisTTL ```86400```, and redisPass to the password set in ```config\redis.config```.
+Now, you can build your docker image.
+Run the command ```docker build -t yourname\g5api:latest .``` Once this has finished, you can run the container using ```docker container run --name g5api -p 3301:3301 -v redisVol:/RedisFiles yourname\g5api:latest```
+
 ### Docs: 
 ```yarn doc```
 

--- a/config/redis.conf
+++ b/config/redis.conf
@@ -1,0 +1,73 @@
+# change these settings:
+requirepass MySecurePassword
+port 6379
+dir /RedisFiles/
+dbfilename dump.rdb
+appendonly no
+appendfilename "appendonly.aof"
+
+# dont change these:
+bind 127.0.0.1
+protected-mode yes
+tcp-backlog 511
+timeout 0
+tcp-keepalive 300
+daemonize no
+supervised systemd
+pidfile /var/run/redis_6379.pid
+loglevel notice
+logfile ""
+databases 16
+always-show-logo yes
+save 900 1
+save 300 10
+save 60 10000
+stop-writes-on-bgsave-error yes
+rdbcompression yes
+rdbchecksum yes
+rdb-del-sync-files no
+replica-serve-stale-data yes
+replica-read-only yes
+repl-diskless-sync no
+repl-diskless-sync-delay 5
+repl-diskless-load disabled
+repl-disable-tcp-nodelay no
+replica-priority 100
+acllog-max-len 128
+lazyfree-lazy-eviction no
+lazyfree-lazy-expire no
+lazyfree-lazy-server-del no
+replica-lazy-flush no
+lazyfree-lazy-user-del no
+oom-score-adj no
+oom-score-adj-values 0 200 800
+appendfsync everysec
+no-appendfsync-on-rewrite no
+auto-aof-rewrite-percentage 100
+auto-aof-rewrite-min-size 64mb
+aof-load-truncated yes
+aof-use-rdb-preamble yes
+lua-time-limit 5000
+slowlog-log-slower-than 10000
+slowlog-max-len 128
+latency-monitor-threshold 0
+notify-keyspace-events ""
+hash-max-ziplist-entries 512
+hash-max-ziplist-value 64
+list-max-ziplist-size -2
+list-compress-depth 0
+set-max-intset-entries 512
+zset-max-ziplist-entries 128
+zset-max-ziplist-value 64
+hll-sparse-max-bytes 3000
+stream-node-max-bytes 4096
+stream-node-max-entries 100
+activerehashing yes
+client-output-buffer-limit normal 0 0 0
+client-output-buffer-limit replica 256mb 64mb 60
+client-output-buffer-limit pubsub 32mb 8mb 60
+hz 10
+dynamic-hz yes
+aof-rewrite-incremental-fsync yes
+rdb-save-incremental-fsync yes
+jemalloc-bg-thread yes


### PR DESCRIPTION
This change adds 2 new files, Dockerfile and config/redis.conf. This change also adds documentation to README.md for instructions on how to build and run the application in a docker container using the Dockerfile.

The Dockerfile base image is redis:latest, and it adds curl, apt-transport-https, lsb-release, gnupg, yarn, nvm, and Node 13.8.0.
It takes the G5API files, adds them into a directory. Then, it installs G5API using the production files, spins up a redis-server, and starts G5API.