### PR TITLE
Change Dockerfile to utilize environmental variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,17 +52,31 @@ Spins up a development server (by default, please use the `NODE_ENV` variable to
 ### Docker Build Instructions:
 This guide assumes you have a MariaDB or MySQL compatible server running. You can deploy one in docker following the [MariaDB guide](https://hub.docker.com/_/mariadb/).
 
-First, you will need to set a password in ```config\redis.conf```.
+Build your docker image.
+Run the command ```docker build -t yourname\g5api:latest .```
+Once this has finished, you can run the container using 
+```
+docker container run --name g5api \
+-p 3301:3301 \
+-v redisVol:/RedisFiles \
+-e PORT="3301" \
+-e HOSTNAME="" \
+-e DBKEY="" \
+-e STEAMAPIKEY="" \
+-e SHAREDSECRET="" \
+-e CLIENTHOME="" \
+-e APIURL="" \
+-e SQLUSER="" \
+-e SQLPASSWORD="" \
+-e DATABASE="" \
+-e SQLHOST="" \
+-e SQLPORT="" \
+-e SUPERADMINS="" \
+-e REDISPASSWORD="" \
+yourname\g5api:latest
+```
 
-Next, rename ```config\production.json.template to config\production.json```.
-
-Fill this file out according to the [configuration](https://github.com/PhlexPlexico/G5API/wiki/Configuration) page. 
-For redisHost, set ```"localhost"```, redisPort ```6379```, redisTTL ```86400```, and redisPass to the password set in ```config\redis.config```.
-
-Now, you can build your docker image.
-Run the command ```docker build -t yourname\g5api:latest .``` 
-Once this has finished, you can run the container using ```docker container run --name g5api -p 3301:3301 -v redisVol:/RedisFiles yourname\g5api:latest```
-
+For more details on these variables, follow along with production.json.template located in /config
 ### Docs: 
 ```yarn doc```
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ docker container run --name g5api \
 -e DATABASE="" \
 -e SQLHOST="" \
 -e SQLPORT="" \
+-e ADMINS="" \
 -e SUPERADMINS="" \
 -e REDISPASSWORD="" \
 yourname\g5api:latest

--- a/config/setEnv.sh
+++ b/config/setEnv.sh
@@ -1,0 +1,18 @@
+#/bin/bash
+
+sed -i "s|\"port\": 3301,|\"port\": $PORT,|g" /Get5API/G5API/config/production.json
+sed -i "s|\"hostname\": \"http://localhost\",|\"hostname\": \"$HOSTNAME\",|g" /Get5API/G5API/config/production.json
+sed -i "s|\"dbKey\": \"Database 16 Byte Key.\",|\"dbKey\": \"$DBKEY\",|g" /Get5API/G5API/config/production.json
+sed -i "s|\"steamAPIKey\": \"API Key For Steam Calls.\",|\"steamAPIKey\": \"$STEAMAPIKEY\",|g" /Get5API/G5API/config/production.json
+sed -i "s|\"sharedSecret\": \"a secure secret for session sigining.\",|\"sharedSecret\": \"$SHAREDSECRET\",|g" /Get5API/G5API/config/production.json
+sed -i "s|\"clientHome\": \"http://localhost:8080\",|\"clientHome\": \"$CLIENTHOME\",|g" /Get5API/G5API/config/production.json
+sed -i "s|\"apiURL\": \"http://localhost:8080/api/\",|\"apiURL\": \"$APIURL\",|g" /Get5API/G5API/config/production.json
+sed -i "s|\"user\": \"get5_user\",|\"user\": \"$SQLUSER\",|g" /Get5API/G5API/config/production.json
+sed -i "s|\"password\": \"\",|\"password\": \"$SQLPASSWORD\",|g" /Get5API/G5API/config/production.json
+sed -i "s|\"database\": \"get5\",|\"database\": \"$DATABASE\",|g" /Get5API/G5API/config/production.json
+sed -i "s|\"host\": \"127.0.0.1\",|\"host\": \"$SQLHOST\",|g" /Get5API/G5API/config/production.json
+sed -i "s|\"port\": 3306,|\"port\": $SQLPORT,|g" /Get5API/G5API/config/production.json
+sed -i "s|\"steam_ids\": \"admins,go,here\"|\"steam_ids\": \"$ADMINS\"|g" /Get5API/G5API/config/production.json
+sed -i "s|\"steam_ids\": \"super_admins,go,here\"|\"steam_ids\": \"$SUPERADMINS\"|g" /Get5API/G5API/config/production.json
+sed -i "s|requirepass MySecurePassword|requirepass $REDISPASSWORD|g" /etc/redis/redis.conf
+sed -i "s|\"redisPass\": \"super_secure\"|\"redisPass\": \"$REDISPASSWORD\"|g" /Get5API/G5API/config/production.json


### PR DESCRIPTION
This change sets environmental variables for the dockerfile using the sed command in setEnv.sh.
It will be incompatible with any existing users with the old style docker.

The following variables can be used:
-e PORT="" \
-e HOSTNAME="" \
-e DBKEY="" \
-e STEAMAPIKEY="" \
-e SHAREDSECRET="" \
-e CLIENTHOME="" \
-e APIURL="" \
-e SQLUSER="" \
-e SQLPASSWORD="" \
-e DATABASE="" \
-e SQLHOST="" \
-e SQLPORT="" \
-e ADMINS="" \
-e SUPERADMINS="" \
-e REDISPASSWORD=""