### PR TITLE
Fix ports, g5api now actually runs on 3301

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,8 +42,8 @@ services:
     container_name: G5API
     volumes: 
       - redisVol:/RedisFiles
-    expose:
-      - 3301
+    ports:
+      - "3301:3301"
     environment:
       - PORT=3301
       - HOSTNAME=


### PR DESCRIPTION
This got me down a rabbit hole on why the matches stopped being ended on panel and I stopped receiving any kind of stats. It was because the g5api wasn't able to be contacted by the game server.