### PR TITLE
Remote Backup/Restore

### DIFF
--- a/app.js
+++ b/app.js
@@ -43,6 +43,7 @@ app.use(express.json({ limit: "512kb" }));
 app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use("/demo", express.static("public"));
+app.use("/backups", express.static("public/backups"));
 app.use("/static/img/logos", express.static("public/img/logos"));
 
 // Security defaults with helmet

--- a/routes/matches/matchserver.js
+++ b/routes/matches/matchserver.js
@@ -358,7 +358,7 @@ router.get(
         }
         if (playerStats.length) {
           playerStatSql = "DELETE FROM player_stats WHERE match_id = ?";
-          await db.query(playerStats, [req.params.match_id]);
+          await db.query(playerStatSql, [req.params.match_id]);
         }
         // Let the server cancel the match first, or attempt to?
         let getServerSQL =

--- a/utility/serverrcon.js
+++ b/utility/serverrcon.js
@@ -334,6 +334,26 @@ class ServerRcon {
       throw err;
     }
   }
+
+  /** Attempts to restore a given backup from the API to a new server.
+   * @function
+   * @param {String} backupName - The filename of the backup on the API.
+   * @returns Returns the response from the server.
+   */
+   async restoreBackupFromURL(backupName) {
+    try {
+      if (process.env.NODE_ENV === "test") {
+        return false;
+      }
+      let loadMatchResponse = await this.execute(
+        "get5_loadbackup_url " + backupName
+      );
+      return loadMatchResponse;
+    } catch (err) {
+      console.error("RCON error on restore backup: " + err.toString());
+      throw err;
+    }
+  }
 }
 
 export default ServerRcon;

--- a/utility/serverrcon.js
+++ b/utility/serverrcon.js
@@ -346,7 +346,7 @@ class ServerRcon {
         return false;
       }
       let loadMatchResponse = await this.execute(
-        "get5_loadbackup_url " + backupName
+        "get5_loadbackup_url \"" + backupName + "\""
       );
       return loadMatchResponse;
     } catch (err) {

--- a/utility/utils.js
+++ b/utility/utils.js
@@ -158,7 +158,7 @@ class Utils {
     if (req.isAuthenticated()) {
       return next();
     }
-    res.redirect("auth/steam");
+    res.redirect("/auth/steam");
   }
 
   /** Checks if a user is an admin in the system during their session.


### PR DESCRIPTION
This PR includes a few new routes in order to backup, restore, and list the amount of backups that are currently on the API. Right now, since we are backing up the backup file on round start, the game server integration for automatically backing up will only exist on get5 0.9. However, you should still be able to restore the matches provided you place them in `public/backups/${matchId}/get5_backup_match${req.params.match_id}_map${mapNumber}_round${roundNumber}.cfg`. This will allow the API to update the respective servers and set server ID of the current match, and mark the other one as available.