### PR TITLE
Change demos to use its own folder in public.

### DIFF
--- a/app.js
+++ b/app.js
@@ -41,7 +41,7 @@ app.use(express.raw({ type: "application/octet-stream", limit: "2gb" }));
 app.use(express.json({ limit: "512kb" }));
 app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
-app.use("/demo", express.static("public"));
+app.use("/demo", express.static("public/demos"));
 app.use("/backups", express.static("public/backups"));
 app.use("/static/img/logos", express.static("public/img/logos"));
 

--- a/app.js
+++ b/app.js
@@ -44,6 +44,9 @@ app.use(cookieParser());
 app.use("/demo", express.static("public/demos"));
 app.use("/backups", express.static("public/backups"));
 app.use("/static/img/logos", express.static("public/img/logos"));
+app.use("/resource/flash/econ/tournaments/teams", express.static("public/img/logos"));
+app.use("/materials/panorama/images/tournaments/teams", express.static("public/img/logos"));
+
 
 // Security defaults with helmet
 app.use(helmet());

--- a/routes/legacy/api.js
+++ b/routes/legacy/api.js
@@ -1082,7 +1082,7 @@ router.put(
         .generateAsync({ type: "nodebuffer", compression: "DEFLATE" })
         .then((buf) => {
           writeFile(
-            "public/" + mapStatValues[0].demoFile,
+            "public/demos/" + mapStatValues[0].demoFile,
             buf,
             "binary",
             function (err) {


### PR DESCRIPTION
Closes #223 

Also included is additional routes to the images directory, which now users should be allowed to setup the FastDL cvars to point to the API, making a more complete solution for team logo upload/downloads.

Please note that this change will break all demos. You will need to move all the zipped demo files into the new `demos/` directory under `public`. After moving, it should fix this issue.