### PR TITLE
Include Wingman Option in Config

### DIFF
--- a/migrations/development/20230626223210-get5db.js
+++ b/migrations/development/20230626223210-get5db.js
@@ -1,0 +1,29 @@
+"use strict";
+
+var dbm;
+var type;
+var seed;
+var async = require("async");
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function (db, callback) {
+  return db.runSql(
+    "ALTER TABLE `match` ADD COLUMN wingman tinyint(1) DEFAULT 0 AFTER map_sides;"
+  );
+};
+
+exports.down = function (db, callback) {
+  return db.removeColumn("match", "wingman");
+};
+exports._meta = {
+  version: 25
+};

--- a/migrations/production/20230626223210-get5db.js
+++ b/migrations/production/20230626223210-get5db.js
@@ -1,0 +1,29 @@
+"use strict";
+
+var dbm;
+var type;
+var seed;
+var async = require("async");
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function (db, callback) {
+  return db.runSql(
+    "ALTER TABLE `match` ADD COLUMN wingman tinyint(1) DEFAULT 0 AFTER map_sides;"
+  );
+};
+
+exports.down = function (db, callback) {
+  return db.removeColumn("match", "wingman");
+};
+exports._meta = {
+  version: 25
+};

--- a/migrations/test/20230626223210-get5db.js
+++ b/migrations/test/20230626223210-get5db.js
@@ -1,0 +1,29 @@
+"use strict";
+
+var dbm;
+var type;
+var seed;
+var async = require("async");
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function (db, callback) {
+  return db.runSql(
+    "ALTER TABLE `match` ADD COLUMN wingman tinyint(1) DEFAULT 0 AFTER map_sides;"
+  );
+};
+
+exports.down = function (db, callback) {
+  return db.removeColumn("match", "wingman");
+};
+exports._meta = {
+  version: 25
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "g5api",
-  "version": "2.0.0.1",
+  "version": "2.0.1.0",
   "private": true,
   "type": "module",
   "licenses": [

--- a/src/routes/matches/matches.js
+++ b/src/routes/matches/matches.js
@@ -117,6 +117,9 @@ import GlobalEmitter from "../../utility/emitter.js";
  *         match_cvars:
  *           type: object
  *           description: An object of key-value pairs containing different unique match CVARs.
+ *         wingman:
+ *           type: boolean
+ *           description: Flag indicating whether the gamemode is wingman or not.
  *
  *     MatchConfig:
  *        type: object
@@ -1035,7 +1038,8 @@ router.get("/:match_id/config", async (req, res, next) => {
       min_spectators_to_ready:
         matchInfo[0].min_spectators_to_ready !== null
           ? matchInfo[0].min_spectators_to_ready
-          : 0
+          : 0,
+      wingman: matchInfo[0]?.wingman == 1 ? true : false
     };
     matchJSON.num_maps = parseInt(matchInfo[0].max_maps);
     if (matchJSON.skip_veto && matchInfo[0].map_sides)
@@ -1162,7 +1166,8 @@ router.post("/", Utils.ensureAuthenticated, async (req, res, next) => {
         req.body[0].min_spectators_to_ready !== null
           ? req.body[0].min_spectators_to_ready
           : 0,
-      map_sides: req.body[0].map_sides !== null ? req.body[0].map_sides : null
+      map_sides: req.body[0].map_sides !== null ? req.body[0].map_sides : null,
+      wingman: req.body[0]?.wingman 
     };
     let sql = "INSERT INTO `match` SET ?";
     let cvarSql =
@@ -1371,7 +1376,8 @@ router.put("/", Utils.ensureAuthenticated, async (req, res, next) => {
           req.body[0].min_spectators_to_ready !== null
             ? req.body[0].min_spectators_to_ready
             : 0,
-        map_sides: req.body[0].map_sides !== null ? req.body[0].map_sides : null
+        map_sides: req.body[0].map_sides !== null ? req.body[0].map_sides : null,
+        wingman: req.body[0]?.wingman
       };
       // Remove any values that may not be updated.
       updateStmt = await db.buildUpdateStatement(updateStmt);


### PR DESCRIPTION
Include wingman in post and put calls for match creation.

Also include wingman in the config, so it will be shown to get5. This may be a breaking change for loading configs when wingman was not an option for older releases of get5.