### PR TITLE
Fixed isCoach assignment while creating a new team

### DIFF
--- a/src/routes/teams.js
+++ b/src/routes/teams.js
@@ -399,7 +399,7 @@ router.post("/", Utils.ensureAuthenticated, async (req, res) => {
       "INSERT INTO team_auth_names (team_id, auth, name, captain, coach) VALUES (?, ?, ?, ?, ?)";
     for (let key in auths) {
       let isCaptain = auths[key].captain == null ? 0 : auths[key].captain;
-      let isCoach = auths[key].captain == null ? 0 : auths[key].coach;
+      let isCoach = auths[key].coach == null ? 0 : auths[key].coach;
       let usersSteamId = await Utils.getSteamPID(key);
       await db.query(sql, [
         teamID,


### PR DESCRIPTION
Fixed isCoach assignment to check for 'coach' key instead of 'captain' key while creating a new team and inserting players in it (POST on /teams).
Not a major issue, but fixing this could be useful while POSTing on /teams manually 