### PR TITLE
Fixed demo file extension on remote upload

### DIFF
--- a/src/routes/v2/demoapi.ts
+++ b/src/routes/v2/demoapi.ts
@@ -150,7 +150,7 @@ router.post("/", async (req: Request, res: Response) => {
       });
     // Update map stats object to include the link to the demo.
     updateStmt = {
-      demoFile: demoFilename.replace("dem", "zip")
+      demoFile: demoFilename.replace(".dem", ".zip")
     };
     updateStmt = await db.buildUpdateStatement(updateStmt);
 


### PR DESCRIPTION
Fixed demo file extension when uploaded through remote URL
(Previous code replaced text `Academy` to `Acazipy` which resulted in wrong demo URL being stored in the database) 