### PR TITLE
fix: Update Server Response Functions

### DIFF
--- a/src/types/serverrcon/SteamApiResponse.ts
+++ b/src/types/serverrcon/SteamApiResponse.ts
@@ -3,7 +3,7 @@ export interface SteamApiResponse {
         success: boolean
         up_to_date: boolean
         version_is_listable: boolean
-        required_version: boolean
+        required_version?: boolean
         message?: string
     }
 }

--- a/src/types/serverrcon/SteamApiResponse.ts
+++ b/src/types/serverrcon/SteamApiResponse.ts
@@ -3,7 +3,7 @@ export interface SteamApiResponse {
         success: boolean
         up_to_date: boolean
         version_is_listable: boolean
-        required_version?: boolean
+        required_version?: number
         message?: string
     }
 }

--- a/src/utility/serverrcon.ts
+++ b/src/utility/serverrcon.ts
@@ -36,7 +36,7 @@ class ServerRcon {
     try {
       await this.rcon.connect();
       const response = await this.rcon.send(commandString);
-      console.log(response);
+      console.debug(response);
       this.rcon.disconnect();
       return response;
     } catch (error) {
@@ -120,8 +120,9 @@ class ServerRcon {
         return false;
       }
       let serverResponse: string = await this.execute("status");
-
+      console.log(`SERVER RESPONSE FROM THE status CALL\n${serverResponse}`);
       let match = serverResponse.match(/\/(\d+)/);
+      console.log(`MATCHED GROUP (/\\/(\\d+)/) IS THE FOLLOWING\n ${match}`);
       let serverVersion: string | undefined = match?.[1];
 
       if (!serverVersion) {

--- a/src/utility/serverrcon.ts
+++ b/src/utility/serverrcon.ts
@@ -119,7 +119,7 @@ class ServerRcon {
         return false;
       }
       let serverResponse: string = await this.execute("status");
-      let serverVersion = serverResponse.match(/(?<=\/)\d+/)?.toString();
+      let serverVersion: string | undefined = serverResponse.match(/(?<=\/)\d+/)?.toString();
 
       if (!serverVersion) {
         throw new Error("Failed to extract server version from response.");

--- a/src/utility/serverrcon.ts
+++ b/src/utility/serverrcon.ts
@@ -120,10 +120,19 @@ class ServerRcon {
         return false;
       }
       let serverResponse: string = await this.execute("status");
-      let serverVersion: string | undefined = serverResponse.match(/(?<=\/)\d+/)?.toString();
+
+      let match = serverResponse.match(/\/(\d+)/);
+      let serverVersion: string | undefined = match?.[1];
+
+      if (!serverVersion) {
+        throw new Error("Failed to extract server version from response.");
+      }
+
       let response = await fetch(
         `https://api.steampowered.com/ISteamApps/UpToDateCheck/v0001/?appid=730&version=${serverVersion}&format=json`
       );
+
+      
       let data: SteamApiResponse = await response.json() as SteamApiResponse;
       if (!data.response.up_to_date) {
         console.log(

--- a/src/utility/serverrcon.ts
+++ b/src/utility/serverrcon.ts
@@ -36,7 +36,6 @@ class ServerRcon {
     try {
       await this.rcon.connect();
       const response = await this.rcon.send(commandString);
-      console.debug(response);
       this.rcon.disconnect();
       return response;
     } catch (error) {
@@ -102,7 +101,7 @@ class ServerRcon {
       if (process.env.NODE_ENV === "test") {
         return false;
       }
-      let get5Status = await this.execute("status");
+      let get5Status = await this.execute("net_public_adr");
       return get5Status != "";
     } catch (err) {
       console.error("Error on game server: " + (err as Error).toString());
@@ -120,10 +119,7 @@ class ServerRcon {
         return false;
       }
       let serverResponse: string = await this.execute("status");
-      console.log(`SERVER RESPONSE FROM THE status CALL\n${serverResponse}`);
-      let match = serverResponse.match(/\/(\d+)/);
-      console.log(`MATCHED GROUP (/\\/(\\d+)/) IS THE FOLLOWING\n ${match}`);
-      let serverVersion: string | undefined = match?.[1];
+      let serverVersion = serverResponse.match(/(?<=\/)\d+/)?.toString();
 
       if (!serverVersion) {
         throw new Error("Failed to extract server version from response.");


### PR DESCRIPTION
Apparently getting the status one after the other during an RCON call will cause the second input to not be read, leading to an empty response. Instead, we are going to use a different call to check for server availability.

