### PR TITLE
Merge queue-integration-cont into queue-integration

### DIFF
--- a/__test__/gameservers.test.js
+++ b/__test__/gameservers.test.js
@@ -14,6 +14,26 @@ describe("Test the game server routes.", () => {
       .expect("Content-Type", /json/)
       .expect(200);
   });
+  it("Should return public server count via GET /servers/publiccount", () => {
+    return request
+      .get("/servers/publiccount")
+      .expect("Content-Type", /json/)
+      .expect(200)
+      .expect((res) => {
+        expect(res.body).toHaveProperty("servers");
+        expect(typeof res.body.servers).toBe("number");
+      });
+  });
+  it("Should return available servers via GET /servers/available", () => {
+    return request
+      .get("/servers/available")
+      .expect("Content-Type", /json/)
+      .expect(200)
+      .expect((res) => {
+        expect(res.body).toHaveProperty("servers");
+        expect(Array.isArray(res.body.servers)).toBe(true);
+      });
+  });
   it("Should setup a new server with the given values.", () => {
     let newServerData = [
       {

--- a/__test__/queue.test.js
+++ b/__test__/queue.test.js
@@ -33,7 +33,7 @@ describe('Queue routes', () => {
     const extraUsers = ['76561198025644195','76561198025644196','76561198025644197'];
     // Add users directly to the queue service to simulate distinct steam IDs (route uses req.user)
     for (const id of extraUsers) {
-      await QueueService.addUserToQueue(slug, id);
+      await QueueService.addUserToQueue(slug, id, 'TestUser');
     }
 
     // Now trigger team creation from the service (would normally be called by the route once full)
@@ -48,6 +48,69 @@ describe('Queue routes', () => {
     const teamId = teams[0].id;
     const auths = await db.query('SELECT auth FROM team_auth_names WHERE team_id = ?', [teamId]);
     expect(auths.length).toBeGreaterThan(0);
+  });
+
+  it('should list queues via GET /queue/', async () => {
+    const res = await request.get('/queue/').expect(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBeGreaterThanOrEqual(1);
+    const names = res.body.map((q) => q.name);
+    expect(names).toContain(global.__TEST_QUEUE_SLUG);
+  });
+
+  it('should get queue by slug via GET /queue/:slug', async () => {
+    const slug = global.__TEST_QUEUE_SLUG;
+    const res = await request.get(`/queue/${slug}`).expect(200);
+    expect(res.body.name).toBe(slug);
+    expect(res.body.maxSize).toBe(4);
+    expect(typeof res.body.currentPlayers).toBe('number');
+  });
+
+  it('should get queue players via GET /queue/:slug/players', async () => {
+    const slug = global.__TEST_QUEUE_SLUG;
+    const res = await request.get(`/queue/${slug}/players`).expect(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should reject duplicate join via PUT /queue/:slug with action join', async () => {
+    const slug = global.__TEST_QUEUE_SLUG;
+    const res = await request
+      .put(`/queue/${slug}`)
+      .set('Content-Type', 'application/json')
+      .send([{ action: 'join' }])
+      .expect(500);
+    expect(res.body.error).toBeDefined();
+  });
+
+  it('should leave queue and delete when last user via PUT leave', async () => {
+    const createRes = await request
+      .post('/queue/')
+      .set('Content-Type', 'application/json')
+      .send([{ maxPlayers: 2, private: false }])
+      .expect(200);
+    const leaveSlug = createRes.body.url.split('/').pop();
+    await request
+      .put(`/queue/${leaveSlug}`)
+      .set('Content-Type', 'application/json')
+      .send([{ action: 'leave' }])
+      .expect(200);
+    await request.get(`/queue/${leaveSlug}`).expect(404);
+  });
+
+  it('should delete queue via DELETE /queue/ with body slug', async () => {
+    const createRes = await request
+      .post('/queue/')
+      .set('Content-Type', 'application/json')
+      .send([{ maxPlayers: 5, private: false }])
+      .expect(200);
+    const deleteSlug = createRes.body.url.split('/').pop();
+    await request
+      .delete('/queue/')
+      .set('Content-Type', 'application/json')
+      .send([{ slug: deleteSlug }])
+      .expect(200);
+    await request.get(`/queue/${deleteSlug}`).expect(404);
   });
 
   describe('rating normalization', () => {

--- a/config/development.json.template
+++ b/config/development.json.template
@@ -12,7 +12,8 @@
     "localLoginEnabled": true,
     "redisUrl": "redis://:super_secure@localhost:6379",
     "redisTTL": 86400,
-    "queueTTL": 3600
+    "queueTTL": 3600,
+    "serverPingTimeoutMs": 5000
   },
   "development": {
     "driver": "mysql",

--- a/config/development.json.template
+++ b/config/development.json.template
@@ -31,6 +31,15 @@
   },
   "super_admins": {
     "steam_ids": "super_admins,go,here"
-  }
+  },
+  "defaultMaps": [
+    { "map_name": "de_inferno", "map_display_name": "Inferno" },
+    { "map_name": "de_ancient", "map_display_name": "Ancient" },
+    { "map_name": "de_mirage", "map_display_name": "Mirage" },
+    { "map_name": "de_nuke", "map_display_name": "Nuke" },
+    { "map_name": "de_anubis", "map_display_name": "Anubis" },
+    { "map_name": "de_dust2", "map_display_name": "Dust II" },
+    { "map_name": "de_vertigo", "map_display_name": "Vertigo" }
+  ]
 }
   

--- a/config/production.json.template
+++ b/config/production.json.template
@@ -12,7 +12,8 @@
     "localLoginEnabled": $LOCALLOGINS,
     "redisUrl": "$REDISURL",
     "redisTTL": $REDISTTL,
-    "queueTTL": $QUEUETTL
+    "queueTTL": $QUEUETTL,
+    "serverPingTimeoutMs": $SERVERPINGTO
   },
   "production": {
     "driver": "mysql",

--- a/config/production.json.template
+++ b/config/production.json.template
@@ -31,5 +31,14 @@
   },
   "super_admins": {
     "steam_ids": "$SUPERADMINS"
-  }
+  },
+  "defaultMaps": [
+    { "map_name": "de_inferno", "map_display_name": "Inferno" },
+    { "map_name": "de_ancient", "map_display_name": "Ancient" },
+    { "map_name": "de_mirage", "map_display_name": "Mirage" },
+    { "map_name": "de_nuke", "map_display_name": "Nuke" },
+    { "map_name": "de_anubis", "map_display_name": "Anubis" },
+    { "map_name": "de_dust2", "map_display_name": "Dust II" },
+    { "map_name": "de_vertigo", "map_display_name": "Vertigo" }
+  ]
 }

--- a/config/test.json.template
+++ b/config/test.json.template
@@ -12,7 +12,8 @@
     "localLoginEnabled": true,
     "redisUrl": "redis://:super_secure@localhost:6379",
     "redisTTL": 86400,
-    "queueTTL": 3600
+    "queueTTL": 3600,
+    "serverPingTimeoutMs": 5000
   },
   "test": {
     "driver": "mysql",

--- a/config/test.json.template
+++ b/config/test.json.template
@@ -31,6 +31,15 @@
   },
   "super_admins": {
     "steam_ids": "super_admins,go,here"
-  }
+  },
+  "defaultMaps": [
+    { "map_name": "de_inferno", "map_display_name": "Inferno" },
+    { "map_name": "de_ancient", "map_display_name": "Ancient" },
+    { "map_name": "de_mirage", "map_display_name": "Mirage" },
+    { "map_name": "de_nuke", "map_display_name": "Nuke" },
+    { "map_name": "de_anubis", "map_display_name": "Anubis" },
+    { "map_name": "de_dust2", "map_display_name": "Dust II" },
+    { "map_name": "de_vertigo", "map_display_name": "Vertigo" }
+  ]
 }
   

--- a/src/routes/queue.ts
+++ b/src/routes/queue.ts
@@ -325,30 +325,47 @@ router.put('/:slug', Utils.ensureAuthenticated, async (req, res) => {
   const action: string = req.body[0]?.action ? req.body[0].action : 'join';
 
   try {
-    let currentQueueCount: number = await QueueService.getCurrentQueuePlayerCount(slug);
-    let maxQueueCount: number = await QueueService.getCurrentQueueMaxCount(slug);
+    const maxQueueCount: number = await QueueService.getCurrentQueueMaxCount(slug);
     if (action === 'join') {
       await QueueService.addUserToQueue(slug, req.user?.steam_id!, req.user?.name!);
-      currentQueueCount++;
-      if (currentQueueCount == maxQueueCount) {
-        // Queue is full — create teams and persist them.
-        // Create match from queue
-        try {
-          const teamIds = await QueueService.createTeamsFromQueue(slug);
-          console.log('Created teams from full queue:', teamIds);
-          const matchId = await QueueService.createMatchFromQueue(slug, teamIds);
-          return res.status(200).json({ success: true, matchId: matchId, message: 'Match created successfully from full queue.' });
-        } catch (err) {
-          console.error('Error creating teams or match from queue:', err);
-          res.status(500).json({ error: `Failed to create teams or match from queue.` });
-          // Fall through to return success=true but without teams
+      const currentQueueCount = await QueueService.getCurrentQueuePlayerCount(slug);
+      if (currentQueueCount === maxQueueCount) {
+        const acquired = await QueueService.tryAcquireQueueLock(slug);
+        if (acquired) {
+          try {
+            const countAfterLock = await QueueService.getCurrentQueuePlayerCount(slug);
+            if (countAfterLock === maxQueueCount) {
+              const teamIds = await QueueService.createTeamsFromQueue(slug);
+              console.log('Created teams from full queue:', teamIds);
+              const matchId = await QueueService.createMatchFromQueue(slug, teamIds);
+              if (matchId != null) {
+                return res.status(200).json({ success: true, matchId, message: 'Match created successfully from full queue.' });
+              }
+              await QueueService.deleteTeams(teamIds);
+              res.status(500).json({ error: 'Failed to create match from queue.' });
+              return;
+            }
+          } catch (err) {
+            console.error('Error creating teams or match from queue:', err);
+            res.status(500).json({ error: 'Failed to create teams or match from queue.' });
+            return;
+          } finally {
+            await QueueService.releaseQueueLock(slug);
+          }
         }
       }
     } else if (action === 'leave') {
       await QueueService.removeUserFromQueue(slug, req.user?.steam_id!, req.user?.steam_id!);
-      if (currentQueueCount == 0) {
-        // If no users are left in the queue, delete it.
-        await QueueService.deleteQueue(slug, req.user?.steam_id!, 'admin');
+      const newCount = await QueueService.getCurrentQueuePlayerCount(slug);
+      if (newCount === 0) {
+        let role: string = 'user';
+        if (req.user?.admin) role = 'admin';
+        else if (req.user?.super_admin) role = 'super_admin';
+        try {
+          await QueueService.deleteQueue(slug, req.user?.steam_id!, role);
+        } catch (_) {
+          // Permission denied (e.g. not owner) or queue already gone; leave still succeeded
+        }
       }
     } else {
       return res.status(400).json({ error: 'Invalid action. Must be "join" or "leave".' });

--- a/src/routes/servers.ts
+++ b/src/routes/servers.ts
@@ -291,7 +291,11 @@ router.get("/myservers", Utils.ensureAuthenticated, async (req, res, next) => {
  */
 router.get("/:server_id", Utils.ensureAuthenticated, async (req, res, next) => {
   try {
-    let serverID: number = parseInt(req.params.server_id);
+    let serverID: number = parseInt(req.params.server_id, 10);
+    if (Number.isNaN(serverID) || serverID < 1) {
+      res.status(400).json({ message: "Invalid server ID." });
+      return;
+    }
     let sql: string;
     let server: RowDataPacket[];
     if (req.user && Utils.superAdminCheck(req.user)) {
@@ -358,10 +362,15 @@ router.get(
   Utils.ensureAuthenticated,
   async (req, res, next) => {
     try {
+      const serverID = parseInt(req.params.server_id, 10);
+      if (Number.isNaN(serverID) || serverID < 1) {
+        res.status(400).json({ message: "Invalid server ID." });
+        return;
+      }
       let userCheckSql: string =
         "SELECT user_id, ip_string, port, rcon_password FROM game_server WHERE id=?";
       let userId: number = req.user!.id;
-      let serverInfo: RowDataPacket[] = await db.query(userCheckSql, [req.params.server_id]);
+      let serverInfo: RowDataPacket[] = await db.query(userCheckSql, [serverID]);
       if (!serverInfo.length) {
         res.status(404).json({ message: "Server does not exist." });
         return;

--- a/src/services/queue.ts
+++ b/src/services/queue.ts
@@ -68,17 +68,6 @@ export class QueueService {
     // Generate API key for the match (used when preparing the server)
     const apiKey = generate({ length: 24, capitalization: "uppercase" });
 
-    // Default CS2 map pool
-    const defaultCs2Maps = [
-      'de_inferno',
-      'de_ancient',
-      'de_mirage',
-      'de_nuke',
-      'de_anubis',
-      'de_dust2',
-      'de_vertigo'
-    ];
-
     // Try to load user's map_list if available
     let mapPool: string[] = [];
     let ownerUserId: number | null = await getUserIdFromMetaSlug(slug);
@@ -93,7 +82,9 @@ export class QueueService {
       mapPool = [];
     }
     console.log("Map pool for user", ownerUserId, ":", mapPool);
-    if (!mapPool || mapPool.length === 0) mapPool = defaultCs2Maps;
+    if (!mapPool || mapPool.length === 0) {
+      mapPool = (config.get("defaultMaps") as { map_name: string }[]).map(m => m.map_name);
+    }
 
     // Build base match object
     const baseMatch: any = {

--- a/src/services/queue.ts
+++ b/src/services/queue.ts
@@ -113,7 +113,7 @@ export class QueueService {
     };
 
     // Fetch candidate servers (include connection info)
-    /*let candidates: RowDataPacket[] = [];
+    let candidates: RowDataPacket[] = [];
     try {
       if (ownerUserId && ownerUserId > 0) {
         candidates = await db.query(
@@ -130,29 +130,23 @@ export class QueueService {
     }
     console.log(`Found ${candidates.length} candidates servers for match from queue ${slug}.`);
 
-    // Try available game servers (disabled for now). If one found then prepare match on it.
     for (const cand of candidates) {
       try {
         const newServer: GameServer = new GameServer(cand.ip_string, cand.port, cand.rcon_password);
 
-        // Check basic server readiness before any DB insert
         const alive = await newServer.isServerAlive();
         const get5av = await newServer.isGet5Available().catch(() => false);
         if (!alive || !get5av) {
-          // server not suitable, try next candidate
-          (GlobalEmitter as any).emit('match:creating', { matchId, serverId: cand.id, teams: teamIds, slug, message: 'Server not alive or not available' });
+          (GlobalEmitter as any).emit('match:creating', { serverId: cand.id, teams: teamIds, slug, message: 'Server not alive or not available' });
           continue;
         }
 
-        // Server looks usable — insert the match and then attempt to prepare it
         const insertSet = await db.buildUpdateStatement({ ...baseMatch, server_id: cand.id }) as any;
         const insertRes: any = await db.query("INSERT INTO `match` SET ?", [insertSet]);
         const matchId = (insertRes as any).insertId;
 
-        // mark server in use
         await db.query("UPDATE game_server SET in_use = 1 WHERE id = ?", [cand.id]);
 
-        // update plugin version on match if we can
         try {
           const get5Version: string = await newServer.getGet5Version();
           await db.query("UPDATE `match` SET plugin_version = ? WHERE id = ?", [get5Version, matchId]);
@@ -160,7 +154,6 @@ export class QueueService {
           // ignore version retrieval errors
         }
 
-        // attempt to prepare match on server
         try {
           const prepared = await newServer.prepareGet5Match(
             config.get("server.apiURL") + "/matches/" + matchId + "/config",
@@ -168,19 +161,17 @@ export class QueueService {
           );
 
           if (!prepared) {
-            // cleanup match and free server
             await db.query("DELETE FROM match_spectator WHERE match_id = ?", [matchId]);
             await db.query("DELETE FROM match_cvar WHERE match_id = ?", [matchId]);
             await db.query("DELETE FROM `match` WHERE id = ?", [matchId]);
             await db.query("UPDATE game_server SET in_use = 0 WHERE id = ?", [cand.id]);
-            continue; // try next candidate
+            continue;
           }
 
-          // success: emit event and return
+          await this.deleteQueue(slug, meta.ownerId!);
           (GlobalEmitter as any).emit('match:created', { matchId, serverId: cand.id, teams: teamIds, slug });
           return matchId;
         } catch (errPrepare) {
-          // prepare failed — cleanup and continue
           try {
             await db.query("DELETE FROM match_spectator WHERE match_id = ?", [matchId]);
             await db.query("DELETE FROM match_cvar WHERE match_id = ?", [matchId]);
@@ -192,7 +183,6 @@ export class QueueService {
           continue;
         }
       } catch (err: any) {
-        // On any error, try to cleanup and continue
         try {
           if (err && err.insertId) {
             const mid = err.insertId;
@@ -205,16 +195,14 @@ export class QueueService {
         }
         continue;
       }
-    }*/
+    }
 
-    // Remove the queue from Redis, including global queue.
-    await this.deleteQueue(slug, meta.ownerId!);
-
-    // No game server found, create match without server.
+    // No game server found (or no candidates), create match without server.
     try {
       const insertSet = await db.buildUpdateStatement({ ...baseMatch, server_id: null }) as any;
       const insertRes: any = await db.query("INSERT INTO `match` SET ?", [insertSet]);
       const matchId = (insertRes as any).insertId;
+      await this.deleteQueue(slug, meta.ownerId!);
       (GlobalEmitter as any).emit('match:created', { matchId, serverId: null, teams: teamIds, slug });
       return matchId;
     } catch (err) {
@@ -276,9 +264,7 @@ export class QueueService {
       hltvRating: hltvRating ?? undefined,
       nickname: name
     };
-    meta.currentPlayers += 1;
     await redis.rPush(key, JSON.stringify(item));
-    
   }
 
   static async removeUserFromQueue(
@@ -304,7 +290,6 @@ export class QueueService {
       const parsed = JSON.parse(item);
       if (parsed.steamId === steamId) {
         await redis.lRem(key, 1, item);
-        meta.currentPlayers -= 1;
         return true;
       }
     }
@@ -330,9 +315,13 @@ export class QueueService {
 
     for (const slug of slugs) {
       const metaRaw = await redis.get(`queue-meta:${slug}`);
-      if (!metaRaw) continue;
+      if (!metaRaw) {
+        await redis.sRem('queues', slug);
+        continue;
+      }
 
       const meta: QueueDescriptor = JSON.parse(metaRaw);
+      meta.currentPlayers = await redis.lLen(`queue:${slug}`);
 
       if (role === 'admin' || role === 'super_admin' || meta.ownerId === requestorSteamId || meta.isPrivate === false) {
         descriptors.push(meta);
@@ -351,13 +340,38 @@ export class QueueService {
   }
 
   static async getCurrentQueuePlayerCount(slug: string): Promise<number> {
-    const meta = await getQueueMetaOrThrow(slug);
-    return meta.currentPlayers;
+    await getQueueMetaOrThrow(slug);
+    const key = `queue:${slug}`;
+    return await redis.lLen(key);
   }
 
   static async getCurrentQueueMaxCount(slug: string): Promise<number> {
     const meta = await getQueueMetaOrThrow(slug);
     return meta.maxSize;
+  }
+
+  private static readonly QUEUE_LOCK_TTL_MS = 10000;
+
+  static async tryAcquireQueueLock(slug: string): Promise<boolean> {
+    if (redis.isOpen === false) await redis.connect();
+    const key = `queue-lock:${slug}`;
+    const result = await redis.set(key, '1', { NX: true, PX: this.QUEUE_LOCK_TTL_MS });
+    return result != null;
+  }
+
+  static async releaseQueueLock(slug: string): Promise<void> {
+    await redis.del(`queue-lock:${slug}`);
+  }
+
+  static async deleteTeams(teamIds: number[]): Promise<void> {
+    for (const tid of teamIds) {
+      try {
+        await db.query("DELETE FROM team_auth_names WHERE team_id = ?", [tid]);
+        await db.query("DELETE FROM team WHERE id = ?", [tid]);
+      } catch (err) {
+        console.error("Error deleting team on rollback:", tid, err);
+      }
+    }
   }
 
   // Normalize player ratings helper

--- a/src/utility/auth.ts
+++ b/src/utility/auth.ts
@@ -49,7 +49,6 @@ async function returnStrategy(identifier: any, profile: any, done: any) {
   process.nextTick(async () => {
     profile.identifier = identifier;
     try {
-      let defaultMaps = [];
       let isAdmin = 0;
       let isSuperAdmin = 0;
       let superAdminList = (config.get("super_admins.steam_ids") as String).split(",");
@@ -84,13 +83,8 @@ async function returnStrategy(identifier: any, profile: any, done: any) {
         curUser = await db.query(sql, [newUser]);
         sql = "SELECT * FROM user WHERE steam_id = ?";
         curUser = await db.query(sql, [profile.id]);
-        defaultMaps.push(['de_inferno', 'Inferno', curUser[0].id]);
-        defaultMaps.push(['de_ancient', 'Ancient', curUser[0].id]);
-        defaultMaps.push(['de_mirage', 'Mirage', curUser[0].id]);
-        defaultMaps.push(['de_nuke', 'Nuke', curUser[0].id]);
-        defaultMaps.push(['de_anubis', 'Anubis', curUser[0].id]);
-        defaultMaps.push(['de_dust2', 'Dust II', curUser[0].id]);
-        defaultMaps.push(['de_vertigo', 'Vertigo', curUser[0].id]);
+        const defaultMapsConfig = config.get("defaultMaps") as { map_name: string; map_display_name: string }[];
+        const defaultMaps = defaultMapsConfig.map(m => [m.map_name, m.map_display_name, curUser[0].id]);
         sql = "INSERT INTO map_list (map_name, map_display_name, user_id) VALUES ?";
         await db.query(sql, [defaultMaps]);
       } else {
@@ -107,14 +101,8 @@ async function returnStrategy(identifier: any, profile: any, done: any) {
         sql = "SELECT * FROM map_list WHERE user_id = ?";
         let checkMaps = await db.query(sql, [curUser[0].id]);
         if (checkMaps.length < 1) {
-          let defaultMaps = [];
-          defaultMaps.push(['de_inferno', 'Inferno', curUser[0].id]);
-          defaultMaps.push(['de_ancient', 'Ancient', curUser[0].id]);
-          defaultMaps.push(['de_mirage', 'Mirage', curUser[0].id]);
-          defaultMaps.push(['de_nuke', 'Nuke', curUser[0].id]);
-          defaultMaps.push(['de_anubis', 'Anubis', curUser[0].id]);
-          defaultMaps.push(['de_dust2', 'Dust II', curUser[0].id]);
-          defaultMaps.push(['de_vertigo', 'Vertigo', curUser[0].id]);
+          const defaultMapsConfig = config.get("defaultMaps") as { map_name: string; map_display_name: string }[];
+          const defaultMaps = defaultMapsConfig.map(m => [m.map_name, m.map_display_name, curUser[0].id]);
           sql = "INSERT INTO map_list (map_name, map_display_name, user_id) VALUES ?";
           await db.query(sql, [defaultMaps]);
         }
@@ -185,7 +173,6 @@ passport.use('local-register',
         return done(null, false, {message: "Sorry, local logins are disabled for this instance."});
       }
       let sql = "SELECT * FROM user WHERE username = ? OR steam_id = ?";
-      let defaultMaps = [];
       let superAdminList = (config.get("super_admins.steam_ids") as String).split(",");
       let adminList = (config.get("admins.steam_ids") as String).split(",");
       let isAdmin, isSuperAdmin = 0;
@@ -225,13 +212,8 @@ passport.use('local-register',
         await db.query(sql, newUser);
         sql = "SELECT * FROM user WHERE steam_id = ?";
         curUser = await db.query(sql, [req.body.steam_id]);
-        defaultMaps.push(['de_inferno', 'Inferno', curUser[0].id]);
-        defaultMaps.push(['de_ancient', 'Ancient', curUser[0].id]);
-        defaultMaps.push(['de_mirage', 'Mirage', curUser[0].id]);
-        defaultMaps.push(['de_nuke', 'Nuke', curUser[0].id]);
-        defaultMaps.push(['de_anubis', 'Anubis', curUser[0].id]);
-        defaultMaps.push(['de_dust2', 'Dust II', curUser[0].id]);
-        defaultMaps.push(['de_vertigo', 'Vertigo', curUser[0].id]);
+        const defaultMapsConfig = config.get("defaultMaps") as { map_name: string; map_display_name: string }[];
+        const defaultMaps = defaultMapsConfig.map(m => [m.map_name, m.map_display_name, curUser[0].id]);
         sql = "INSERT INTO map_list (map_name, map_display_name, user_id) VALUES ?";
         await db.query(sql, [defaultMaps]);
         return done(null, {

--- a/src/utility/serverrcon.ts
+++ b/src/utility/serverrcon.ts
@@ -1,8 +1,13 @@
+import config from "config";
 import Utils from "./utils.js";
 import { Rcon } from "dathost-rcon-client";
 import fetch from "node-fetch";
 import { compare } from "compare-versions";
 import { SteamApiResponse } from "../types/serverrcon/SteamApiResponse.js";
+
+const RCON_TIMEOUT_MS = config.has("server.serverPingTimeoutMs")
+  ? config.get<number>("server.serverPingTimeoutMs")
+  : 5000;
 
 /**
  * Creates a new server object to run various tasks.
@@ -33,14 +38,29 @@ class ServerRcon {
   }
 
   async execute(commandString: string): Promise<string> {
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      setTimeout(() => reject(new Error(`RCON timeout after ${RCON_TIMEOUT_MS}ms`)), RCON_TIMEOUT_MS);
+    });
+    const executePromise = (async () => {
+      try {
+        await this.rcon.connect();
+        const response = await this.rcon.send(commandString);
+        this.rcon.disconnect();
+        return response;
+      } catch (error) {
+        console.error("[RCON] Got error: " + error);
+        throw error;
+      }
+    })();
     try {
-      await this.rcon.connect();
-      const response = await this.rcon.send(commandString);
-      this.rcon.disconnect();
-      return response;
-    } catch (error) {
-      console.error("[RCON] Got error: " + error);
-      throw error;
+      return await Promise.race([executePromise, timeoutPromise]);
+    } catch (err) {
+      try {
+        this.rcon.disconnect();
+      } catch (_) {
+        // ignore disconnect errors on timeout
+      }
+      throw err;
     }
   }
 


### PR DESCRIPTION
## Summary

Additional changes for queue integration: concurrency safety, server assignment, configurable timeouts, and tests.

## Changes

### Queue flow & concurrency
- **Lock when queue fills:** When the queue reaches max size, the flow now uses a Redis lock (`tryAcquireQueueLock` / `releaseQueueLock`) so only one process creates teams and a match. Player count is re-checked after acquiring the lock.
- **Leave/delete:** On leave, queue deletion uses the requester's role (user / admin / super_admin). Delete is wrapped in try/catch so leave still succeeds if the user can't delete (e.g. not owner).
- **Player count:** `currentPlayers` is no longer stored on the queue meta; it is derived from Redis list length so it stays correct. List-queues logic recomputes it and drops stale slugs from the global set.

### Match creation from queue
- **Server assignment re-enabled:** The candidate game-server path (previously commented out) is re-enabled. When a queue fills, the service:
  - Fetches candidate servers (by owner or public),
  - For each candidate: checks server alive + Get5 available, creates match row, marks server in use, prepares Get5 match via RCON,
  - On success: deletes the queue and returns the match ID,
  - On failure or no suitable server: falls back to creating a match with `server_id: null` and then deletes the queue.
- **Rollback:** Added `deleteTeams` and use it when match creation fails after creating teams.

### Servers API
- **Validation:** GET `/servers/:server_id` and the related route now parse `server_id` with radix 10 and return 400 for invalid values (NaN or < 1). DB queries use the parsed integer.

### RCON & config
- **Timeout:** RCON `execute()` uses a configurable timeout (`server.serverPingTimeoutMs`, default 5000 ms). Promise.race with a timeout promise; on timeout/error, connection is disconnected before rethrowing.
- **Config templates:** `serverPingTimeoutMs` added to development, test, and production json templates (5000 in dev/test, $SERVERPINGTO in prod).

### Tests
- **Game servers:** Tests for GET `/servers/publiccount` and GET `/servers/available`.
- **Queue:** `addUserToQueue` in tests now passes display name (TestUser). New tests for: list queues, get queue by slug, get queue players, duplicate join (expect 500), leave as last user (queue deleted), and DELETE `/queue/` with slug.

## Files touched
- `src/routes/queue.ts`, `src/services/queue.ts` — queue lock, server assignment, player count from Redis, leave/delete behavior.
- `src/routes/servers.ts` — server ID validation.
- `src/utility/serverrcon.ts` — RCON timeout.
- `config/*.json.template` — `serverPingTimeoutMs`.
- `__test__/gameservers.test.js`, `__test__/queue.test.js` — new and updated tests.
