### PR TITLE
Add SSE Endpoint for Queue

### DIFF
--- a/src/routes/queue.ts
+++ b/src/routes/queue.ts
@@ -7,8 +7,40 @@ import config from "config";
 import { Router } from 'express';
 import Utils from "../utility/utils.js";
 import { QueueService } from "../services/queue.js";
+import GlobalEmitter from "../utility/emitter.js";
 
 const router = Router();
+
+const getRequesterRole = (req: any): string => {
+  let role: string = 'user';
+  if (req.user?.admin) role = 'admin';
+  else if (req.user?.super_admin) role = 'super_admin';
+  return role;
+};
+
+const buildQueueState = async (slug: string): Promise<any> => {
+  try {
+    const users = await QueueService.listUsersInQueue(slug);
+    const queue = await QueueService.getQueue(slug, 'admin', '');
+    return {
+      slug,
+      queue: {
+        ...queue,
+        currentPlayers: users.length,
+      },
+      users,
+    };
+  } catch (error: any) {
+    if (
+      error?.message?.includes('does not exist') ||
+      error?.message?.includes('missing') ||
+      error?.message?.includes('not found')
+    ) {
+      return { slug, queue: null, users: [] };
+    }
+    throw error;
+  }
+};
 
 
 /**
@@ -142,6 +174,74 @@ router.get('/:slug', async (req, res) => {
       return res.status(404).json({ error: 'Queue not found.' });
     }
     res.status(500).json({ error: 'Failed to fetch queue.' });
+  }
+});
+
+/**
+* @swagger
+*
+* /queue/:slug/stream:
+*   get:
+*     description: Stream queue state changes for join/leave and match creation events.
+*     produces:
+*       - text/event-stream
+*     tags:
+*       - queue
+*     parameters:
+*       - name: slug
+*         in: path
+*         required: true
+*         schema:
+*           type: string
+*     responses:
+*       200:
+*         description: Queue state stream.
+*       500:
+*         $ref: '#/components/responses/Error'
+*/
+router.get('/:slug/stream', async (req, res) => {
+  const slug: string = req.params.slug;
+  try {
+    res.set({
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+      "Content-Type": "text/event-stream",
+      "X-Accel-Buffering": "no"
+    });
+    res.flushHeaders();
+
+    const writeState = async (matchEvent: any = null) => {
+      const snapshot = await buildQueueState(slug);
+      const payload = {
+        ...snapshot,
+        match: matchEvent?.matchId != null ? {
+          id: matchEvent.matchId,
+          serverId: matchEvent.serverId ?? null
+        } : null
+      };
+      res.write(`event: queue_state\ndata: ${JSON.stringify(payload)}\n\n`);
+    };
+
+    const onQueueUpdate = async (event: any) => {
+      if (!event || event.slug !== slug) return;
+      await writeState(event.match ?? null);
+    };
+
+    GlobalEmitter.on("queueUpdate", onQueueUpdate);
+    await writeState();
+
+    req.on("close", () => {
+      GlobalEmitter.removeListener("queueUpdate", onQueueUpdate);
+      res.end();
+    });
+    req.on("disconnect", () => {
+      GlobalEmitter.removeListener("queueUpdate", onQueueUpdate);
+      res.end();
+    });
+  } catch (error) {
+    console.error('Error streaming queue state:', error);
+    res.status(500).write(`event: error\ndata: ${(error as Error).toString()}\n\n`);
+    res.end();
   }
 });
 
@@ -329,6 +429,13 @@ router.put('/:slug', Utils.ensureAuthenticated, async (req, res) => {
     if (action === 'join') {
       await QueueService.addUserToQueue(slug, req.user?.steam_id!, req.user?.name!);
       const currentQueueCount = await QueueService.getCurrentQueuePlayerCount(slug);
+      GlobalEmitter.emit("queueUpdate", {
+        slug,
+        action: "join",
+        actorSteamId: req.user?.steam_id,
+        currentQueueCount,
+        maxQueueCount
+      });
       if (currentQueueCount === maxQueueCount) {
         const acquired = await QueueService.tryAcquireQueueLock(slug);
         if (acquired) {
@@ -358,15 +465,20 @@ router.put('/:slug', Utils.ensureAuthenticated, async (req, res) => {
       await QueueService.removeUserFromQueue(slug, req.user?.steam_id!, req.user?.steam_id!);
       const newCount = await QueueService.getCurrentQueuePlayerCount(slug);
       if (newCount === 0) {
-        let role: string = 'user';
-        if (req.user?.admin) role = 'admin';
-        else if (req.user?.super_admin) role = 'super_admin';
+        const role: string = getRequesterRole(req);
         try {
           await QueueService.deleteQueue(slug, req.user?.steam_id!, role);
         } catch (_) {
           // Permission denied (e.g. not owner) or queue already gone; leave still succeeded
         }
       }
+      GlobalEmitter.emit("queueUpdate", {
+        slug,
+        action: "leave",
+        actorSteamId: req.user?.steam_id,
+        currentQueueCount: newCount,
+        maxQueueCount
+      });
     } else {
       return res.status(400).json({ error: 'Invalid action. Must be "join" or "leave".' });
     }
@@ -424,9 +536,7 @@ router.put('/:slug', Utils.ensureAuthenticated, async (req, res) => {
     const slug: string = req.body[0].slug;
 
     try {
-      let role: string = 'user';
-      if (req.user?.admin) role = 'admin';
-      else if (req.user?.super_admin) role = 'super_admin';
+      const role: string = getRequesterRole(req);
       await QueueService.deleteQueue(slug, req.user?.steam_id!, role);
       res.status(200).json({ message: "The queue has successfully been deleted!", success: true });
     } catch (error: Error | any) {

--- a/src/services/queue.ts
+++ b/src/services/queue.ts
@@ -100,7 +100,8 @@ export class QueueService {
       enforce_teams: 1,
       is_pug: 1,
       api_key: apiKey,
-      min_player_ready: meta.maxSize/2
+      min_player_ready: meta.maxSize/2,
+      players_per_team: meta.maxSize/2
     };
 
     // Fetch candidate servers (include connection info)
@@ -160,6 +161,11 @@ export class QueueService {
           }
 
           await this.deleteQueue(slug, meta.ownerId!);
+          (GlobalEmitter as any).emit('queueUpdate', {
+            slug,
+            action: 'match_created',
+            match: { matchId, serverId: cand.id }
+          });
           (GlobalEmitter as any).emit('match:created', { matchId, serverId: cand.id, teams: teamIds, slug });
           return matchId;
         } catch (errPrepare) {
@@ -194,6 +200,11 @@ export class QueueService {
       const insertRes: any = await db.query("INSERT INTO `match` SET ?", [insertSet]);
       const matchId = (insertRes as any).insertId;
       await this.deleteQueue(slug, meta.ownerId!);
+      (GlobalEmitter as any).emit('queueUpdate', {
+        slug,
+        action: 'match_created',
+        match: { matchId, serverId: null }
+      });
       (GlobalEmitter as any).emit('match:created', { matchId, serverId: null, teams: teamIds, slug });
       return matchId;
     } catch (err) {


### PR DESCRIPTION
## Summary

This PR adds real-time queue state streaming so clients can react immediately to queue membership and match creation events without polling.

- Adds `GET /queue/:slug/stream` as an SSE endpoint that emits `queue_state` updates with:
  - latest queue snapshot
  - current users in queue
  - optional match info (`id`, `serverId`) when a match is created
- Emits `queueUpdate` events on queue `join` and `leave` actions in `queue` route handlers.
- Emits `queueUpdate` with `match_created` payload when queue processing creates a match (with or without a selected server).
- Refactors repeated role detection into a shared `getRequesterRole()` helper in queue routes.
- Includes `players_per_team` in match creation payload for queue-driven matches.

## Why

The frontend queue page and live hooks need push-based updates for queue activity and match transitions. SSE + queue events provide a simple, low-latency mechanism to keep clients in sync and reduce polling complexity.

## Test plan

- [x] Start API and connect to stream:
  - `curl -N http://<api>/queue/<slug>/stream`
- [x] Join queue from another authenticated client and verify a `queue_state` event is received with incremented `currentPlayers`.
- [x] Leave queue and verify a `queue_state` event is received with decremented `currentPlayers`.
- [x] Fill queue to trigger match creation and verify stream emits `queue_state` with `match.id` and `match.serverId` (or `null` when no server assigned).
- [x] Verify queue cleanup still works when last player leaves and no permission regression is introduced.
- [x] Confirm existing queue endpoints (`GET /queue/:slug`, `PUT /queue/:slug`) continue to behave as before.